### PR TITLE
feat: automatic channel reconnection

### DIFF
--- a/src/ack.rs
+++ b/src/ack.rs
@@ -14,7 +14,11 @@ impl<M: Send + 'static, Res: Send + Sync + 'static, C> Acknowledge<Res, AmqpCont
         res: &Result<Res, BoxDynError>,
         parts: &Parts<AmqpContext, u64>,
     ) -> Self::Future {
-        let channel = self.channel.clone();
+        let channel = self
+            .channel
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone();
         let tag = parts.ctx.tag().value();
         let is_ok = res.is_ok();
         async move {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,9 +42,42 @@ use std::{
     io::{self},
     marker::PhantomData,
     str::FromStr,
-    sync::Arc,
+    sync::{Arc, RwLock},
 };
 use utils::{AmqpContext, Config, DeliveryTag};
+
+/// Creates a new channel from the pool, re-declares the queue, and updates
+/// `channel_lock` if the previous channel is disconnected.
+async fn try_reconnect(
+    pool: &Pool,
+    channel_lock: &Arc<RwLock<Channel>>,
+    config: &Config,
+    worker_name: &str,
+) -> Result<Channel, lapin::Error> {
+    let amqp_conn = pool.get().await.map_err(|error| {
+        lapin::ErrorKind::IOError(Arc::new(io::Error::new(
+            io::ErrorKind::ConnectionRefused,
+            error,
+        )))
+    })?;
+
+    let new_channel = amqp_conn.create_channel().await?;
+    let _ = new_channel
+        .queue_declare(
+            config.namespace(),
+            config.declare_options(),
+            FieldTable::default(),
+        )
+        .await?;
+
+    let mut guard = channel_lock.write().unwrap_or_else(|e| e.into_inner());
+    if !guard.status().connected() {
+        *guard = new_channel.clone();
+        tracing::info!("Reconnected channel for worker {worker_name}");
+    }
+
+    Ok(new_channel)
+}
 
 /// Contains basic utilities for handling config and messages
 pub mod utils;
@@ -59,7 +92,8 @@ pub type AmqpTaskId = TaskId<u64>;
 /// A wrapper around a `lapin` AMQP channel that implements message queuing functionality.
 #[pin_project]
 pub struct AmqpBackend<M, Codec> {
-    channel: Channel,
+    pool: Pool,
+    channel: Arc<RwLock<Channel>>,
     queue: lapin::Queue,
     message_type: PhantomData<M>,
     config: Config,
@@ -70,7 +104,8 @@ pub struct AmqpBackend<M, Codec> {
 impl<M, C> Clone for AmqpBackend<M, C> {
     fn clone(&self) -> Self {
         Self {
-            channel: self.channel.clone(),
+            pool: self.pool.clone(),
+            channel: Arc::clone(&self.channel),
             queue: self.queue.clone(),
             message_type: PhantomData,
             config: self.config.clone(),
@@ -92,26 +127,23 @@ where
     type Context = AmqpContext;
     type IdType = u64;
     fn heartbeat(&self, worker: &WorkerContext) -> Self::Beat {
-        let channel = self.channel.clone();
+        let channel = Arc::clone(&self.channel);
         let worker = worker.clone();
         let config = self.config.clone();
         let stream = stream::unfold(
             (channel, worker, config),
             move |(channel, worker, config)| async move {
                 apalis_core::timer::sleep(config.heartbeat_interval()).await;
-                let is_connected = channel.status().connected();
+                let is_connected = channel
+                    .read()
+                    .unwrap_or_else(|e| e.into_inner())
+                    .status()
+                    .connected();
+
                 if !is_connected {
-                    Some((
-                        Err(ErrorKind::IOError(Arc::new(io::Error::new(
-                            io::ErrorKind::NotConnected,
-                            format!("Channel not connected for worker {}", worker.name()),
-                        )))
-                        .into()),
-                        (channel, worker, config),
-                    ))
-                } else {
-                    Some((Ok(()), (channel, worker, config)))
+                    tracing::warn!("Channel not connected for worker {}. Waiting for poll_delivery to reconnect.", worker.name());
                 }
+                Some((Ok(()), (channel, worker, config)))
             },
         );
         stream.boxed()
@@ -178,19 +210,31 @@ impl<M, C> AmqpBackend<M, C> {
         self,
         worker: &WorkerContext,
     ) -> impl Stream<Item = Result<Delivery, Error>> + 'static {
-        let channel = self.channel.clone();
-        let worker = worker.clone();
+        let pool = self.pool.clone();
+        let channel = Arc::clone(&self.channel);
         let config = self.config.clone();
         let worker_name = worker.name().to_string();
 
         let stream = stream::once(async move {
+            // If the stored channel is dead, reconnect it.
+            let ch = if channel
+                .read()
+                .unwrap_or_else(|e| e.into_inner())
+                .status()
+                .connected()
+            {
+                channel.read().unwrap_or_else(|e| e.into_inner()).clone()
+            } else {
+                try_reconnect(&pool, &channel, &config, &worker_name).await?
+            };
+
             // Set QoS/prefetch before consuming to limit memory usage
             let qos = config.qos_options();
             if qos.prefetch_count > 0 {
-                channel.basic_qos(qos.prefetch_count, qos.options).await?;
+                ch.basic_qos(qos.prefetch_count, qos.options).await?;
             }
 
-            let consumer = channel
+            let consumer = ch
                 .basic_consume(
                     config.namespace().as_str(),
                     &worker_name,
@@ -207,28 +251,42 @@ impl<M, C> AmqpBackend<M, C> {
 
 impl<M: Send + 'static> AmqpBackend<M, ()> {
     /// Constructs a new instance of `AmqpBackend` from a `lapin` channel.
-    pub fn new(channel: Channel, queue: lapin::Queue) -> AmqpBackend<M, JsonCodec<Vec<u8>>> {
-        Self::new_with_config(channel, queue, Config::new(std::any::type_name::<M>()))
+    pub fn new(
+        pool: Pool,
+        channel: Channel,
+        queue: lapin::Queue,
+    ) -> AmqpBackend<M, JsonCodec<Vec<u8>>> {
+        Self::new_with_config(
+            pool,
+            channel,
+            queue,
+            Config::new(std::any::type_name::<M>()),
+        )
     }
 
     /// Constructs a new instance of `AmqpBackend` with a config
     pub fn new_with_config(
+        pool: Pool,
         channel: Channel,
         queue: lapin::Queue,
         config: Config,
     ) -> AmqpBackend<M, JsonCodec<Vec<u8>>> {
         AmqpBackend {
+            pool,
             sink: sink::AmqpSink::new(),
-            channel,
+            channel: Arc::new(RwLock::new(channel)),
             message_type: PhantomData,
             queue,
             config,
         }
     }
 
-    /// Get a ref to the inner `Channel`
-    pub fn channel(&self) -> &Channel {
-        &self.channel
+    /// Get a clone of the inner `Channel`
+    pub fn channel(&self) -> Channel {
+        self.channel
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone()
     }
 
     /// Get a ref to the inner `Queue`
@@ -283,7 +341,7 @@ impl<M: Send + 'static> AmqpBackend<M, ()> {
                 FieldTable::default(),
             )
             .await?;
-        Ok(Self::new_with_config(channel, queue, config))
+        Ok(Self::new_with_config(pool, channel, queue, config))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,8 @@ async fn try_reconnect(
     config: &Config,
     worker_name: &str,
 ) -> Result<Channel, lapin::Error> {
+    apalis_core::timer::sleep(config.reconnection_delay()).await;
+
     let amqp_conn = pool.get().await.map_err(|error| {
         lapin::ErrorKind::IOError(Arc::new(io::Error::new(
             io::ErrorKind::ConnectionRefused,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
     clippy::await_holding_lock,
     clippy::cargo_common_metadata,
     clippy::dbg_macro,
-    clippy::empty_enum,
+    clippy::empty_enums,
     clippy::enum_glob_use,
     clippy::inefficient_to_string,
     clippy::mem_forget,

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -96,7 +96,11 @@ where
 
     fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         let namespace = self.config.namespace().to_owned();
-        let channel = self.channel.clone();
+        let channel = self
+            .channel
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone();
         let sink = self.project().sink.project();
 
         // First, convert any queued items to pending sends

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -39,6 +39,7 @@ pub struct Config {
     heartbeat_interval: Duration,
     qos_options: QosOptions,
     declare_options: QueueDeclareOptions,
+    reconnection_delay: Duration,
 }
 
 impl Config {
@@ -50,6 +51,7 @@ impl Config {
             heartbeat_interval: Duration::from_secs(60),
             qos_options: QosOptions::default(),
             declare_options: QueueDeclareOptions::default(),
+            reconnection_delay: Duration::from_secs(3),
         }
     }
 
@@ -101,6 +103,16 @@ impl Config {
     /// Sets the queue declaration options.
     pub fn set_declare_options(&mut self, options: QueueDeclareOptions) {
         self.declare_options = options;
+    }
+
+    /// Gets the heartbeat interval.
+    pub fn reconnection_delay(&self) -> Duration {
+        self.reconnection_delay
+    }
+
+    /// Sets the heartbeat interval.
+    pub fn set_reconnection_delay(&mut self, delay: Duration) {
+        self.reconnection_delay = delay;
     }
 }
 


### PR DESCRIPTION
## Description
Following up on [#44](https://github.com/apalis-dev/apalis-amqp/issues/44) and inspired by the solution proposed there, this PR implements automatic channel reconnection so workers can recover from connection drops without a manual restart.

## Problem
Previously, `AmqpBackend` discarded the `deadpool_lapin::Pool` after initialization, storing only a single `Channel`. Any network interruption would leave the channel in a broken state with no way to recover, permanently killing the worker (see [#44](https://github.com/apalis-dev/apalis-amqp/issues/44)).

## Solution
As proposed in [#44](https://github.com/apalis-dev/apalis-amqp/issues/44) by @levish0, the pool is now stored in `AmqpBackend` and the channel is wrapped in an `Arc<RwLock<Channel>>`. When `poll_delivery` detects a disconnected channel, it calls `try_reconnect`, which waits `config.reconnection_delay()` (default 3s, configurable via `config.set_reconnection_delay(...)`), then fetches a fresh connection from the pool, re-declares the queue, and resumes consuming — no manual restart required.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)

## Additional Notes
**Breaking change:** `AmqpBackend::new()` and `new_with_config()` now require a `Pool` as an additional parameter.

## Testing
cargo check ✅
cargo clippy --all-targets --all-features -- -D warnings ✅
cargo fmt --all -- --check ✅
cargo test -- --test-threads=1 ✅ (RabbitMQ 4.2.1)